### PR TITLE
Added 656 area code

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -9865,6 +9865,9 @@
 				"651": {
 					"type": "mobile"
 				},
+				"656": {
+					"type": "mobile"
+				},
 				"657": {
 					"type": "mobile"
 				},


### PR DESCRIPTION
656 Area code is now being used in Tampa Florida, USA